### PR TITLE
Feature:webpの書き出しタスクを追加

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -13,6 +13,7 @@ const autoprefixer = require('autoprefixer');
 const cleanCSS = require('gulp-clean-css'); // 圧縮
 const rename = require('gulp-rename'); // ファイル名変更
 const sourcemaps = require('gulp-sourcemaps'); // ソースマップ作成
+const webp = require('gulp-webp');
 
 //js babel
 const babel = require('gulp-babel');
@@ -120,6 +121,17 @@ const imgImagemin = () => {
 		.pipe(dest(destPath.img));
 };
 
+const changeWebp = () => {
+	return src(srcPath.img)
+		.pipe(
+			rename((path) => {
+				path.basename += path.extname;
+			})
+		)
+		.pipe(webp())
+		.pipe(dest(destPath.img));
+};
+
 //ローカルサーバー立ち上げ、ファイル監視と自動リロード
 const browserSyncFunc = () => {
 	browserSync.init(browserSyncOption);
@@ -142,9 +154,10 @@ const watchFiles = () => {
 	watch(srcPath.css, series(cssSass, browserSyncReload));
 	watch(srcPath.js, series(jsBabel, browserSyncReload));
 	watch(srcPath.img, series(imgImagemin, browserSyncReload));
+	watch(srcPath.img, series(changeWebp, browserSyncReload));
 };
 
 exports.default = series(
-	series(cssSass, jsBabel, imgImagemin),
+	series(cssSass, jsBabel, imgImagemin, changeWebp),
 	parallel(watchFiles, browserSyncFunc)
 );

--- a/package-lock.json
+++ b/package-lock.json
@@ -4778,8 +4778,7 @@
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/console-stream/-/console-stream-0.1.1.tgz",
       "integrity": "sha1-oJX+B7IEZZVfL6/Si11yvM2UnUQ=",
-      "dev": true,
-      "optional": true
+      "dev": true
     },
     "content-disposition": {
       "version": "0.5.3",
@@ -5050,6 +5049,17 @@
       "dev": true,
       "requires": {
         "array-find-index": "^1.0.1"
+      }
+    },
+    "cwebp-bin": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/cwebp-bin/-/cwebp-bin-5.1.0.tgz",
+      "integrity": "sha512-BsPKStaNr98zfxwejWWLIGELbPERULJoD2v5ijvpeutSAGsegX7gmABgnkRK7MUucCPROXXfaPqkLAwI509JzA==",
+      "dev": true,
+      "requires": {
+        "bin-build": "^3.0.0",
+        "bin-wrapper": "^4.0.1",
+        "logalot": "^2.1.0"
       }
     },
     "d": {
@@ -5797,7 +5807,6 @@
       "resolved": "https://registry.npmjs.org/exec-buffer/-/exec-buffer-3.2.0.tgz",
       "integrity": "sha512-wsiD+2Tp6BWHoVv3B+5Dcx6E7u5zky+hUwOHjuH2hKSLR3dvRmX8fk8UD8uqQixHs4Wk6eDmiegVrMPjKj7wpA==",
       "dev": true,
-      "optional": true,
       "requires": {
         "execa": "^0.7.0",
         "p-finally": "^1.0.0",
@@ -5811,7 +5820,6 @@
           "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-5.1.0.tgz",
           "integrity": "sha1-6L0O/uWPz/b4+UUQoKVUu/ojVEk=",
           "dev": true,
-          "optional": true,
           "requires": {
             "lru-cache": "^4.0.1",
             "shebang-command": "^1.2.0",
@@ -5823,7 +5831,6 @@
           "resolved": "https://registry.npmjs.org/execa/-/execa-0.7.0.tgz",
           "integrity": "sha1-lEvs00zEHuMqY6n68nrVpl/Fl3c=",
           "dev": true,
-          "optional": true,
           "requires": {
             "cross-spawn": "^5.0.1",
             "get-stream": "^3.0.0",
@@ -5838,15 +5845,13 @@
           "version": "3.0.0",
           "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-3.0.0.tgz",
           "integrity": "sha1-jpQ9E1jcN1VQVOy+LtsFqhdO3hQ=",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "pify": {
           "version": "3.0.0",
           "resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
           "integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY=",
-          "dev": true,
-          "optional": true
+          "dev": true
         }
       }
     },
@@ -6157,7 +6162,6 @@
       "resolved": "https://registry.npmjs.org/figures/-/figures-1.7.0.tgz",
       "integrity": "sha1-y+Hjr/zxzUS4DK3+0o3Hk6lwHS4=",
       "dev": true,
-      "optional": true,
       "requires": {
         "escape-string-regexp": "^1.0.5",
         "object-assign": "^4.1.0"
@@ -7993,6 +7997,29 @@
         }
       }
     },
+    "gulp-webp": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/gulp-webp/-/gulp-webp-4.0.1.tgz",
+      "integrity": "sha512-ChrghhDJcLDGDNPvH4LwFX2jDOOunKmshYLc4tL3BajL/aGSYXRc+sY51R/6A9veZ7Maf/pzZqzNf6zkfItARA==",
+      "dev": true,
+      "requires": {
+        "imagemin-webp": "^5.0.0",
+        "plugin-error": "^1.0.1",
+        "through2": "^3.0.0"
+      },
+      "dependencies": {
+        "through2": {
+          "version": "3.0.2",
+          "resolved": "https://registry.npmjs.org/through2/-/through2-3.0.2.tgz",
+          "integrity": "sha512-enaDQ4MUyP2W6ZyT6EsMzqBPZaM/avg8iuo+l2d3QCs0J+6RaqkHV/2/lOwDTueBHeJ/2LG9lrLW3d5rWPucuQ==",
+          "dev": true,
+          "requires": {
+            "inherits": "^2.0.4",
+            "readable-stream": "2 || 3"
+          }
+        }
+      }
+    },
     "gulplog": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/gulplog/-/gulplog-1.0.0.tgz",
@@ -8531,6 +8558,17 @@
         "svgo": "^1.3.2"
       }
     },
+    "imagemin-webp": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/imagemin-webp/-/imagemin-webp-5.1.0.tgz",
+      "integrity": "sha512-BsPTpobgbDPFBBsI3UflnU/cpIVa15qInEDBcYBw16qI/6XiB4vDF/dGp9l4aM3pfFDDYqR0mANMcKpBD7wbCw==",
+      "dev": true,
+      "requires": {
+        "cwebp-bin": "^5.0.0",
+        "exec-buffer": "^3.0.0",
+        "is-cwebp-readable": "^2.0.1"
+      }
+    },
     "immutable": {
       "version": "3.8.2",
       "resolved": "https://registry.npmjs.org/immutable/-/immutable-3.8.2.tgz",
@@ -8740,6 +8778,23 @@
       "dev": true,
       "requires": {
         "has": "^1.0.3"
+      }
+    },
+    "is-cwebp-readable": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/is-cwebp-readable/-/is-cwebp-readable-2.0.1.tgz",
+      "integrity": "sha1-r7k7DAq9CiUQEBauM66ort+SbSY=",
+      "dev": true,
+      "requires": {
+        "file-type": "^4.3.0"
+      },
+      "dependencies": {
+        "file-type": {
+          "version": "4.4.0",
+          "resolved": "https://registry.npmjs.org/file-type/-/file-type-4.4.0.tgz",
+          "integrity": "sha1-G2AOX8ofvcboDApwxxyNul95BsU=",
+          "dev": true
+        }
       }
     },
     "is-data-descriptor": {
@@ -9588,7 +9643,6 @@
       "resolved": "https://registry.npmjs.org/logalot/-/logalot-2.1.0.tgz",
       "integrity": "sha1-X46MkNME7fElMJUaVVSruMXj9VI=",
       "dev": true,
-      "optional": true,
       "requires": {
         "figures": "^1.3.5",
         "squeak": "^1.0.0"
@@ -9598,8 +9652,7 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/longest/-/longest-1.0.1.tgz",
       "integrity": "sha1-MKCy2jj3N3DoKUoNIuZiXtd9AJc=",
-      "dev": true,
-      "optional": true
+      "dev": true
     },
     "longest-streak": {
       "version": "2.0.4",
@@ -9628,7 +9681,6 @@
       "resolved": "https://registry.npmjs.org/lpad-align/-/lpad-align-1.1.2.tgz",
       "integrity": "sha1-IfYArBwwlcPG5JfuZyce4ISB/p4=",
       "dev": true,
-      "optional": true,
       "requires": {
         "get-stdin": "^4.0.1",
         "indent-string": "^2.1.0",
@@ -11662,7 +11714,6 @@
       "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
       "integrity": "sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==",
       "dev": true,
-      "optional": true,
       "requires": {
         "glob": "^7.1.3"
       }
@@ -12403,7 +12454,6 @@
       "resolved": "https://registry.npmjs.org/squeak/-/squeak-1.3.0.tgz",
       "integrity": "sha1-MwRQN7ZDiLVnZ0uEMiplIQc5FsM=",
       "dev": true,
-      "optional": true,
       "requires": {
         "chalk": "^1.0.0",
         "console-stream": "^0.1.1",

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "gulp-sourcemaps": "^3.0.0",
     "gulp-stylelint": "^13.0.0",
     "gulp-uglify": "^3.0.2",
+    "gulp-webp": "^4.0.1",
     "imagemin-mozjpeg": "^9.0.0",
     "imagemin-pngquant": "^9.0.1",
     "imagemin-svgo": "^8.0.0",


### PR DESCRIPTION
## 概要
高速化対応のため、次世代拡張子.webpの書き出しができるように、
タスクを追加。

### 追加パッケージ
https://www.npmjs.com/package/gulp-webp

### 対象ファイル
```
gulpfile.js
package-lock.json
package.json
```
画像圧縮のタスク：imgImagemin
webp化のタスク：changeWebp

※ 両方対応できるようにタスクを分けて記述